### PR TITLE
Tojson+silent

### DIFF
--- a/lib/ansible.js
+++ b/lib/ansible.js
@@ -25,7 +25,11 @@ AbstractAnsibleCommand.prototype = {
       currentWorkingDir = shelljs.pwd();
       shelljs.cd(options.cwd);
     }
-    shelljs.exec(this.compile(), function(code, output) {
+    var opt = {};
+    if(options && options.silent) {
+        opt.silent = true;
+    }
+    shelljs.exec(this.compile(), opt, function(code, output) {
       if (currentWorkingDir) {
         shelljs.cd(currentWorkingDir);
       }

--- a/lib/ansible.js
+++ b/lib/ansible.js
@@ -3,6 +3,7 @@ var _ = require('underscore');
 var format = require('util').format;
 var inherits = require('util').inherits;
 var utils = require('./utils');
+var ansible_to_json = require('./json').ansible_to_json;
 var Q = require('q');
 
 var AbstractAnsibleCommand = function() {}
@@ -33,7 +34,11 @@ AbstractAnsibleCommand.prototype = {
       if (currentWorkingDir) {
         shelljs.cd(currentWorkingDir);
       }
-      deferred.resolve({code: code, output: output});
+      var ret = {code: code, output: output};
+      if(options && options.json) {
+        ret.json = ansible_to_json(output);
+      }
+      deferred.resolve(ret);
     });
 
     return deferred.promise;

--- a/lib/json.js
+++ b/lib/json.js
@@ -1,0 +1,24 @@
+module.exports.ansible_to_json = function (output) {
+    var lines = output.split("\n");
+    var res = [];
+    var cur = {};
+    var inline = false;
+    for(var i in lines) {
+        var a = null;
+        if((a = lines[i].match(/^(.*) \| (FAILED|success) >> {$/)) !== null) {
+            cur = {};
+            cur.host = a[1];
+            cur.code = a[2];
+            cur.data = ['{'];
+            inline = true;
+        } else if (lines[i] == '}') {
+            inline = false;
+            cur.data.push('}');
+            cur.data = JSON.parse(cur.data.join(''));
+            res.push(cur);
+        } else if(inline) {
+            cur.data.push(lines[i]);
+        }
+    }
+    return res;
+};


### PR DESCRIPTION
I need to be able to parse ansible response as JSON, and having silent mode.

So, now, it can add a json array to result, which is a collection of object using this model:

``` json
{ "host": "XXX",
  "code": "success|FAILED",
  "data": {"var1": "value1", "var2": "value2", ...} 
}
```

so final result is :

``` json
{ "code": "XXX",
  "output": "XXX",
  "json": [ { "host": "XXX", "code": "XXX", "data": "XXX" }, {}, "..." ]
}
```

for compatibility, option must be toggled on using exec({json: true});

I added to silent mode to shelljs,
for compatibility, option must be toggled on using exec({silent: true});

I'ld test more as soon (code) as I far as I would use ansible for my projects.
I'ld have doc if accepted too ;)

Ex:

``` javascript
var Ansible = require('node-ansible');

var cmd = new Ansible.AdHoc().hosts('call').module('mysql_replication').user('root').args({mode: 'getslave'}).verbose(0);
var go = cmd.exec({json: true, silent: true});

go.then(function (result) {
    for(var i in result.json) {
        console.log('Host: ', result.json[i].host, ' DB is ', result.json[i].data['Slave_IO_Running'], result.json[i].data['Slave_SQL_Running'], ' with ', result.json[i].data['Seconds_Behind_Master'], 's');
    }
}
```

results:

> Host:  HOST1  DB is  Yes Yes  with  0 s
> Host:  HOST2  DB is  Yes Yes  with  0 s
> Host:  HOST3  DB is  Yes Yes  with  0 s
