### PR TITLE
Add ask-pass and ask-sudo-pass

### DIFF
--- a/lib/ansible.js
+++ b/lib/ansible.js
@@ -164,10 +164,12 @@ var Playbook = function () {
 
   this.askPass = function() {
     this.config.askPass = true;
+    return this;
   }
 
   this.askSudoPass = function() {
     this.config.askSudoPass = true;
+    return this;
   }
 
   this.playbook = function(playbook) {

--- a/lib/ansible.js
+++ b/lib/ansible.js
@@ -162,6 +162,14 @@ var Playbook = function () {
 
   this.config = {};
 
+  this.askPass = function() {
+    this.config.askPass = true;
+  }
+
+  this.askSudoPass = function() {
+    this.config.askSudoPass = true;
+  }
+
   this.playbook = function(playbook) {
     this.config.playbook = playbook;
     return this;
@@ -190,6 +198,14 @@ var Playbook = function () {
     if (this.config.variables) {
       var args = utils.formatArgs(this.config.variables);
       command += " -e " + args;
+    }
+
+    if (this.config.askPass) {
+      command += " --ask-pass";
+    }
+
+    if (this.config.askSudoPass) {
+      command += " --ask-sudo-pass";
     }
 
     command = this.commonCompile(command);

--- a/test/playbook.spec.js
+++ b/test/playbook.spec.js
@@ -155,8 +155,9 @@ describe('Playbook command', function () {
 
   describe('with --ask-sudo-pass flag', function() {
 
-    it('should execute the playbook with --ask-pass flag', function (done) {
-      var command = new Playbook().playbook('test').askPass();
+    it('should execute the playbook with --ask-sudo-pass flag', function (done) {
+      var command = new Playbook().playbook('test').askSudoPass();
+
       expect(command.exec()).to.be.fulfilled.then(function () {
         expect(execSpy).to.be.calledWith('ansible-playbook test.yml --ask-sudo-pass');
         done();

--- a/test/playbook.spec.js
+++ b/test/playbook.spec.js
@@ -142,6 +142,28 @@ describe('Playbook command', function () {
     })
   })
 
+  describe('with --ask-pass flag', function() {
+
+    it('should execute the playbook with --ask-pass flag', function (done) {
+      var command = new Playbook().playbook('test').askPass();
+      expect(command.exec()).to.be.fulfilled.then(function () {
+        expect(execSpy).to.be.calledWith('ansible-playbook test.yml --ask-pass');
+        done();
+      }).done();
+    })
+  })
+
+  describe('with --ask-sudo-pass flag', function() {
+
+    it('should execute the playbook with --ask-pass flag', function (done) {
+      var command = new Playbook().playbook('test').askPass();
+      expect(command.exec()).to.be.fulfilled.then(function () {
+        expect(execSpy).to.be.calledWith('ansible-playbook test.yml --ask-sudo-pass');
+        done();
+      }).done();
+    })
+  })
+
   after(function () {
     execSpy.restore();
   })


### PR DESCRIPTION
Added functionality to the Playbook() to add '--ask-pass' and/or '--ask-sudo-pass' flags to the ansible-playbook command.

Could substitute the '--ask-sudo-pass' string being concatenated to `command` with '-K'.