### PR TITLE
Added tests for ask-pass and ask-sudo-pass to playbook.spec.js

### DIFF
--- a/lib/ansible.js
+++ b/lib/ansible.js
@@ -162,6 +162,14 @@ var Playbook = function () {
 
   this.config = {};
 
+  this.askPass = function() {
+    this.config.askPass = true;
+  }
+
+  this.askSudoPass = function() {
+    this.config.askSudoPass = true;
+  }
+
   this.playbook = function(playbook) {
     this.config.playbook = playbook;
     return this;
@@ -190,6 +198,14 @@ var Playbook = function () {
     if (this.config.variables) {
       var args = utils.formatArgs(this.config.variables);
       command += " -e " + args;
+    }
+
+    if (this.config.askPass) {
+      command += " --ask-pass";
+    }
+
+    if (this.config.askSudoPass) {
+      command += " --ask-sudo-pass";
     }
 
     command = this.commonCompile(command);

--- a/test/playbook.spec.js
+++ b/test/playbook.spec.js
@@ -142,6 +142,28 @@ describe('Playbook command', function () {
     })
   })
 
+  describe('with --ask-pass flag', function() {
+
+    it('should execute the playbook with --ask-pass flag', function (done) {
+      var command = new Playbook().playbook('test').askPass();
+      expect(command.exec()).to.be.fulfilled.then(function () {
+        expect(execSpy).to.be.calledWith('ansible-playbook test.yml --ask-pass');
+        done();
+      }).done();
+    })
+  })
+
+  describe('with --ask-sudo-pass flag', function() {
+
+    it('should execute the playbook with --ask-pass flag', function (done) {
+      var command = new Playbook().playbook('test').askPass();
+      expect(command.exec()).to.be.fulfilled.then(function () {
+        expect(execSpy).to.be.calledWith('ansible-playbook test.yml --ask-sudo-pass');
+        done();
+      }).done();
+    })
+  })
+
   after(function () {
     execSpy.restore();
   })


### PR DESCRIPTION
Went ahead and added the tests to playbook.spec.js.
I didn't add any documentation since the README is fairly light and the bulk of the documentation is on your github pages site.

Your **Supported Flags** section might include:

--ask-pass
`command.askPass();`

--ask-sudo-pass
`command.askSudoPass();`