### PR TITLE
Update the index.html in gh-pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,8 +119,8 @@
 
         
           <div class='highlight'><pre>promise.then(<span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(result)</span> </span>{
-  <span class="hljs-built_in">console</span>.log(result.code);
   <span class="hljs-built_in">console</span>.log(result.output);
+  <span class="hljs-built_in">console</span>.log(result.code);
 })</pre></div>
         
       
@@ -140,6 +140,16 @@
 
         
           <div class='highlight'><pre>command.exec({cwd:<span class="hljs-string">"/path/to/my/playbooks"</span>})</pre></div>
+        
+      
+        
+        <p> The command is also an EventEmitter, which lets you get the output streamed in real time.</p>
+
+        
+          <div class='highlight'><pre><span class="hljs-keyword">var</span> command = <span class="hljs-keyword">new</span> Ansible.Playbook().playbook(<span class="hljs-string">'my-playbook'</span>);
+command.on(<span class="hljs-string">'stdout'</span>, <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(data)</span> </span>{ <span class="hljs-built_in">console</span>.log(data.toString()); });
+command.on(<span class="hljs-string">'stderr'</span>, <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(data)</span> </span>{ <span class="hljs-built_in">console</span>.log(data.toString()); });
+command.exec();</pre></div>
         
       
         


### PR DESCRIPTION
The index.html in gh-pages is still the old one and the extra documentation is not there when you open the docs. Just updated it.

It also seems that in your last merge you've brought everything from `develop` and before you only had the necessary page files. Maybe you want to do something like what is explained here https://gist.github.com/cobyism/4730490.