### PR TITLE
Add tags and skip-tags support to playbooks

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -103,5 +103,20 @@ command.askSudoPass();
 // verbose level: accepts any level supported by the CLI
 command.verbose('v')
 
+// -e variables
+command.variables({name: 'value'})
+
+// #### Playbook Flags
+
+// --tags=tag
+command.tags('tag');
+command.tags('tag','othertag');
+command.tags(tag_array);
+
+// --skip-tags=tag
+command.skipTags('tag');
+command.skipTags('tag','othertag');
+command.skipTags(tag_array);
+
 // <a href="https://github.com/shaharke/node-ansible"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub"></a>
 

--- a/lib/ansible.js
+++ b/lib/ansible.js
@@ -4,6 +4,7 @@ var inherits = require('util').inherits;
 var utils = require('./utils');
 var Q = require('q');
 var EventEmitter = require('events').EventEmitter;
+var slice = [].slice;
 
 var AbstractAnsibleCommand = function() {
   EventEmitter.call(this);
@@ -22,7 +23,6 @@ AbstractAnsibleCommand.prototype.exec = function(options) {
   }
 
   var deferred = Q.defer();
-
   var processOptions = {};
   if (options && options.cwd) {
     processOptions.cwd = options.cwd;
@@ -215,6 +215,30 @@ var Playbook = function () {
     return this;
   }
 
+  this.tags = function() {
+    var args
+    args = 1 <= arguments.length ? slice.call(arguments, 0) : [];
+    if ( _.isString(args) ) args = Array(args);
+    this.config.tags = args;
+    return this;
+  }
+
+  this.skipTags = function() {
+    var args
+    args = 1 <= arguments.length ? slice.call(arguments, 0) : [];
+    if ( _.isString(args) ) args = Array(args);
+    this.config.skipTags = args;
+    return this;
+  }
+
+  this.addTags = function() {
+    return ('--tags=' + this.config.tags.join(','));
+  }
+
+  this.addSkipTags = function() {
+    return ('--skip-tags=' + this.config.skipTags.join(','));
+  }
+
   this.validate = function() {
     var errors = [];
 
@@ -242,6 +266,16 @@ var Playbook = function () {
 
     if (this.config.askSudoPass) {
       result = result.concat('--ask-sudo-pass');
+    }
+
+    if (this.config.tags) {
+      var tags = this.addTags();
+      result = result.concat(tags);
+    }
+
+    if (this.config.skipTags) {
+      var skipTags = this.addSkipTags();
+      result = result.concat(skipTags);
     }
 
     result = this.commonCompileParams(result);

--- a/test/playbook.spec.js
+++ b/test/playbook.spec.js
@@ -162,6 +162,78 @@ describe('Playbook command', function () {
     })
   })
 
+  describe('with --tags param', function() {
+
+    it('should execute the playbook with --tags', function (done) {
+      var command = new Playbook().playbook('test').tags('onetag');
+
+      expect(command.exec()).to.be.fulfilled.then(function () {
+        expect(spawnSpy).to.be.calledWith('ansible-playbook', ['test.yml', "--tags=onetag"], {});
+        done();
+      }).done();
+    })
+  })
+
+  describe('with --tags params', function() {
+  
+    it('should execute the playbook with multiple --tags', function (done) {
+      var command = new Playbook().playbook('test').tags('onetag','twotags');
+  
+      expect(command.exec()).to.be.fulfilled.then(function () {
+        expect(spawnSpy).to.be.calledWith('ansible-playbook', ['test.yml', "--tags=onetag,twotags"], {});
+        done();
+      }).done();
+    })
+  })
+
+  describe('with --tags array', function() {
+ 
+    it('should execute the playbook with array of --tags', function (done) {
+      var command = new Playbook().playbook('test').tags(['onetag','twotags']);
+ 
+      expect(command.exec()).to.be.fulfilled.then(function () {
+        expect(spawnSpy).to.be.calledWith('ansible-playbook', ['test.yml', "--tags=onetag,twotags"], {});
+        done();
+      }).done();
+    })
+  })
+
+  describe('with --skip-tags param', function() {
+
+    it('should execute the playbook with --skip-tags', function (done) {
+      var command = new Playbook().playbook('test').skipTags('onetag');
+
+      expect(command.exec()).to.be.fulfilled.then(function () {
+        expect(spawnSpy).to.be.calledWith('ansible-playbook', ['test.yml', '--skip-tags=onetag'], {});
+        done();
+      }).done();
+    })
+  })
+
+  describe('with --skip-tags params', function() {
+
+    it('should execute the playbook with multiple --skip-tags', function (done) {
+      var command = new Playbook().playbook('test').skipTags('onetag','twotags');
+
+      expect(command.exec()).to.be.fulfilled.then(function () {
+        expect(spawnSpy).to.be.calledWith('ansible-playbook', ['test.yml', '--skip-tags=onetag,twotags'], {});
+        done();
+      }).done();
+    })
+  })
+
+  describe('with --skip-tags params', function() {
+
+    it('should execute the playbook with array of --skip-tags', function (done) {
+      var command = new Playbook().playbook('test').skipTags(['one tag','twotags']);
+
+      expect(command.exec()).to.be.fulfilled.then(function () {
+        expect(spawnSpy).to.be.calledWith('ansible-playbook', ['test.yml', '--skip-tags=one tag,twotags'], {});
+        done();
+      }).done();
+    })
+  })
+
   after(function () {
     process.spawn = oldSpawn;
     spawnSpy.restore();


### PR DESCRIPTION
Add support for running ansible playbooks with the `--tags` and `--skip-tags` options

--tags=tag

    command.tags('tag');
    command.tags('tag','othertag');
    command.tags(tag_array);

--skip-tags=tag

    command.skipTags('tag');
    command.skipTags('tag','othertag');
    command.skipTags(tag_array);