### PR TITLE
make buffering example functional in new location

### DIFF
--- a/examples/playbook.buffering.js
+++ b/examples/playbook.buffering.js
@@ -3,8 +3,8 @@
 var Path = require('path');
 var Playbook = require("../index").Playbook;
 
-var playbook_file = Path.join(__dirname, 'fixtures', 'buffering')
-var inventory_file = Path.join(__dirname, 'fixtures', 'hosts')
+var playbook_file = Path.join(__dirname, '..', 'test', 'fixtures', 'buffering')
+var inventory_file = Path.join(__dirname, '..', 'test', 'fixtures', 'hosts')
 
 var command = new Playbook().playbook( playbook_file );
 command.inventory( inventory_file );
@@ -20,9 +20,12 @@ commandb.on('stderr', function(data) { console.log("stderr buf: "+data.toString(
 promise.then(function(result){
   console.log("unbuf: "+result.output);
   console.log("unbuf: "+result.code);
+  throw new Error('can you see me?');
   return commandb.exec({buffered:true});
 }).then(function(result){
   console.log("buff:  "+result.output);
   console.log("buff:  "+result.code);
-});
+})//.catch(function(error){
+//  console.log("error!",error)
+//})
 


### PR DESCRIPTION
I didn't update the paths in the buffering example when it was moved from the `test/` directory
