### PR TITLE
Move to bluebird promises via bluebird-q

### DIFF
--- a/lib/ansible.js
+++ b/lib/ansible.js
@@ -2,7 +2,7 @@ var exec = require('child_process');
 var _ = require('underscore');
 var inherits = require('util').inherits;
 var utils = require('./utils');
-var Q = require('q');
+var Q = require('bluebird-q');
 var EventEmitter = require('events').EventEmitter;
 var slice = [].slice;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-ansible",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "Programmatic interface in Node.js for executing Ansible ad-hoc commands and playbooks",
   "main": "index.js",
   "scripts": {
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "mock-spawn": "^0.2.6",
-    "q": "~1.0.0",
+    "bluebird-q": "~1.0.0",
     "underscore": "~1.5.2"
   }
 }


### PR DESCRIPTION
I've had a number of instances where I've been losing exceptions that bluebird picks up with no changes. . Not sure if you are heavily invested in q, but I find bluebird a lot better at error handling and has a few more features. Apparently it's generally faster and consumes less memory as well. 

It's a little more work to convert it into straight bluebird promise's, but not much. 
