### PR TITLE
Added ability to extend exec environment variables

### DIFF
--- a/lib/ansible.js
+++ b/lib/ansible.js
@@ -30,7 +30,7 @@ AbstractAnsibleCommand.prototype.exec = function(options) {
     processOptions.cwd = options.cwd;
   }
 
-  // Make Ansible output unbuffered so the stdout and stderr `data` events 
+  // Make Ansible output unbuffered so the stdout and stderr `data` events
   // pickup output up more regularly
   var unbuffered = (options.buffered) ? '' : 1;
   processOptions.env = process.env;

--- a/lib/ansible.js
+++ b/lib/ansible.js
@@ -35,6 +35,7 @@ AbstractAnsibleCommand.prototype.exec = function(options) {
   var unbuffered = (options.buffered) ? '' : 1;
   processOptions.env = process.env;
   _.extend( processOptions.env, { PYTHONUNBUFFERED: unbuffered } );
+  _.extend( processOptions.env, options.env || {} );
 
   var output = '';
   var child = exec.spawn(this.commandName(), this.compileParams(), processOptions);


### PR DESCRIPTION
Hey guys,
i have got to situation when i need to extend `exec` command environment variables and i don't wanna add it to `process.env`. I have just added additional `_.extend` call for `options.env`.

Take a look and let me know ;)

Vojta
