### PR TITLE
New flag: -l SUBSET

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -179,7 +179,12 @@ command.exec();</pre></div>
         
           <div class='highlight'><pre>command.inventory(<span class="hljs-string">'/etc/ansible/hosts'</span>)</pre></div>
         
-      
+
+        <p> -l hosts_subset</p>
+
+
+          <div class='highlight'><pre>command.limit(<span class="hljs-string">'hosts_subset'</span>)</pre></div>
+
         
         <p> -U root</p>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -180,11 +180,6 @@ command.exec();</pre></div>
           <div class='highlight'><pre>command.inventory(<span class="hljs-string">'/etc/ansible/hosts'</span>)</pre></div>
         
 
-        <p> -l hosts_subset</p>
-
-
-          <div class='highlight'><pre>command.limit(<span class="hljs-string">'hosts_subset'</span>)</pre></div>
-
         
         <p> -U root</p>
 

--- a/lib/ansible.js
+++ b/lib/ansible.js
@@ -88,6 +88,11 @@ AbstractAnsibleCommand.prototype.privateKey = function(privateKey) {
   return this;
 };
 
+AbstractAnsibleCommand.prototype.limit = function(limit) {
+  this.config.limit = limit;
+  return this;
+};
+
 AbstractAnsibleCommand.prototype.su = function(su) {
   this.config.su = su;
   return this;
@@ -135,6 +140,7 @@ AbstractAnsibleCommand.prototype.commonCompileParams = function(commandParams) {
   commandParams = this.addParam(commandParams, "forks", "f");
   commandParams = this.addParam(commandParams, "user", "u");
   commandParams = this.addParam(commandParams, "inventory", "i");
+  commandParams = this.addParam(commandParams, "limit", "l");
   commandParams = this.addParam(commandParams, "su", "U");
   commandParams = this.addPathParam(commandParams, "privateKey", "-private-key");
   commandParams = this.addVerbose(commandParams);

--- a/test/adhoc.spec.js
+++ b/test/adhoc.spec.js
@@ -134,6 +134,30 @@ describe('AdHoc command', function() {
     })
   })
 
+  describe('with inventory subset', function() {
+
+    it('should execute the playbook with specified inventory subset limit', function (done) {
+      var command = new AdHoc().module('shell').hosts('local').inventory('/etc/my/hosts').limit('localhost').args("echo 'hello'");
+      expect(command.exec()).to.be.fulfilled.then(function() {
+        expect(spawnSpy).to.be.calledWith('ansible', ['local', '-m', 'shell', '-a', 'echo \'hello\'', '-i', '/etc/my/hosts', '-l', 'localhost']);
+        done();
+      }).done();
+    })
+
+  })
+
+  describe('with inventory subset', function() {
+
+    it('should execute the playbook with specified inventory subset limit', function (done) {
+      var command = new AdHoc().module('shell').hosts('local').inventory('/etc/my/hosts').limit('localhost').args("echo 'hello'");
+      expect(command.exec()).to.be.fulfilled.then(function() {
+        expect(spawnSpy).to.be.calledWith('ansible', ['local', '-m', 'shell', '-a', 'echo \'hello\'', '-i', '/etc/my/hosts', '-l', 'localhost']);
+        done();
+      }).done();
+    })
+
+  })
+
   describe('with private key', function() {
 
     it('should contain private key flag in execution', function(done) {

--- a/test/playbook.spec.js
+++ b/test/playbook.spec.js
@@ -140,6 +140,18 @@ describe('Playbook command', function () {
 
   })
 
+  describe('with inventory subset', function() {
+
+    it('should execute the playbook with specified inventory subset limit', function (done) {
+      var command = new Playbook().playbook('test').limit("localhost");
+      expect(command.exec()).to.be.fulfilled.then(function () {
+        expect(spawnSpy).to.be.calledWith('ansible-playbook' ,['test.yml', '-l', 'localhost']);
+        done();
+      }).done();
+    })
+
+  })
+
   describe('with private-key', function() {
 
     it('should execute the playbook with specified private key', function (done) {


### PR DESCRIPTION
New flag: -l SUBSET, --limit=SUBSET further limit selected hosts to an additional pattern.

Why:
Node v4 does not accept a spawn with fake-command-params arrays e.g ['-i','hostfile -l myhost']
Now in order to pass additional params we have to set them properly e.g ['-i','hostfile', '-l', 'myhost']
