### PR TITLE
Added support for windows control machine using cygwin.

### DIFF
--- a/lib/ansible.js
+++ b/lib/ansible.js
@@ -340,8 +340,8 @@ var Playbook = function () {
 	}
 	
     if (this.config.variables) {
-      var args = JSON.stringify(this.config.variables);
-      result = result.concat('-e', args);
+      var args = JSON.stringify(this.config.variables, null, ' ');
+      result = result.concat('-e', '"' + args.replace(/(\r\n|\r|\n)/gm,"").replace(/(})/gm, " }") + '"');
     }
 
     if (this.config.askPass) {

--- a/lib/ansible.js
+++ b/lib/ansible.js
@@ -5,6 +5,8 @@ var utils = require('./utils');
 var Q = require('q');
 var EventEmitter = require('events').EventEmitter;
 var slice = [].slice;
+//Are we on a Windows control machine?
+var isWin = /^win/.test(process.platform);
 
 var AbstractAnsibleCommand = function() {
   EventEmitter.call(this);
@@ -37,8 +39,8 @@ AbstractAnsibleCommand.prototype.exec = function(options) {
   _.extend( processOptions.env, { PYTHONUNBUFFERED: unbuffered } );
 
   var output = '';
-  var child = exec.spawn(this.commandName(), this.compileParams(), processOptions);
 
+  var child = exec.spawn(this.commandName(), this.compileParams(), processOptions);
   child.stdout.on('data', function(data) {
     output += data.toString();
     self.emit('stdout', data);
@@ -61,6 +63,16 @@ AbstractAnsibleCommand.prototype.exec = function(options) {
   });
 
   return deferred.promise;
+};
+
+AbstractAnsibleCommand.prototype.cygwinCommand = function(cygwinCommand) {
+	this.config.cygwinCommand = cygwinCommand;
+	return this;
+};
+
+AbstractAnsibleCommand.prototype.ansiblePath = function(ansiblePath) {
+	this.config.ansiblePath = ansiblePath;
+	return this;
 };
 
 AbstractAnsibleCommand.prototype.forks = function(forks) {
@@ -153,12 +165,26 @@ var AdHoc = function() {
 
   AbstractAnsibleCommand.call(this);
 
-  this.commandName = function() {
-    return 'ansible';
-  }
-
   this.config = {};
 
+  this.ansibleCommand = function() {
+	  var command = '';
+	  if(!_.isUndefined(this.config.ansiblePath)){
+		  command = this.config.ansiblePath + 'ansible';
+	  }else{
+		  command = 'ansible';
+	  }
+	  return command;
+  }
+  
+  this.commandName = function() {
+	  if(!isWin){
+		  return this.ansibleCommand();
+	  }else{
+		  return this.config.cygwinCommand;
+	  }
+  }
+  
   this.module = function (module) {
     this.config.module = module;
     return this;
@@ -203,6 +229,10 @@ var AdHoc = function() {
       '-m',
       this.config.module
     ];
+	
+	if(isWin){
+		result.unshift(this.ansibleCommand());
+	}
 
     if (this.config.args || this.config.freeform) {
       var args = utils.formatArgs(this.config.args, this.config.freeform);
@@ -211,9 +241,12 @@ var AdHoc = function() {
 
     result = this.commonCompileParams(result);
 
-    return result;
+	if(isWin){
+		return ['-c', result.join(' ')];
+	}else{
+		return result;
+	}
   }
-
 }
 
 inherits(AdHoc, AbstractAnsibleCommand);
@@ -222,11 +255,25 @@ var Playbook = function () {
 
   AbstractAnsibleCommand.call(this);
 
-  this.commandName = function() {
-    return 'ansible-playbook';
-  }
-
   this.config = {};
+
+  this.ansibleCommand = function() {
+	  var command = '';
+	  if(!_.isUndefined(this.config.ansiblePath)){
+		  command = ansiblePath + 'ansible-playbook';
+	  }else{
+		  command = 'ansible-playbook';
+	  }
+	  return command;
+  }
+  
+  this.commandName = function() {
+	  if(!isWin){
+		  return this.ansibleCommand();
+	  }else{
+		  return this.config.cygwinCommand;
+	  }
+  }
 
   this.askPass = function() {
     this.config.askPass = true;

--- a/lib/ansible.js
+++ b/lib/ansible.js
@@ -242,7 +242,7 @@ var AdHoc = function() {
     result = this.commonCompileParams(result);
 
 	if(isWin){
-		return ['-c', result.join(' ')];
+		return ['-lc', result.join(' ')];
 	}else{
 		return result;
 	}
@@ -260,7 +260,7 @@ var Playbook = function () {
   this.ansibleCommand = function() {
 	  var command = '';
 	  if(!_.isUndefined(this.config.ansiblePath)){
-		  command = ansiblePath + 'ansible-playbook';
+		  command = this.config.ansiblePath + 'ansible-playbook';
 	  }else{
 		  command = 'ansible-playbook';
 	  }
@@ -335,6 +335,10 @@ var Playbook = function () {
       this.config.playbook + ".yml"
     ];
 
+	if(isWin){
+		result.unshift(this.ansibleCommand());
+	}
+	
     if (this.config.variables) {
       var args = JSON.stringify(this.config.variables);
       result = result.concat('-e', args);
@@ -360,7 +364,11 @@ var Playbook = function () {
 
     result = this.commonCompileParams(result);
 
-    return result;
+    if(isWin){
+		return ['-lc', result.join(' ')];
+	}else{
+		return result;
+	}
   }
 }
 


### PR DESCRIPTION
I had to make some changes to node-ansible to be compatible with our windows control machine (we're stuck with Windows for reasons beyond this scope...)  I thought this might be useful for other users.

The ansible.js module detects a windows platform with:
`var isWin = /^win/.test(process.platform)`

This var is used to decide whether to substitute `cygwinCommand` in place of `'ansible'`.  Additionally, support is added for specifying an `ansiblePath` to point to an alternate location.

Ansible is invoked in cygwin with a structure like:

```
console.log('Node-Ansbile Test');

var Ansible = require('node-ansible');
var command = new Ansible.AdHoc()
                        .hosts('cisco')
                        .module('ping')
                        .cygwinCommand('c:/cygwin64/bin/bash.exe')
                        .ansiblePath('/usr/bin/');
var promise = command.exec();
promise.then(function(result) {
        console.log('Got good output');
        console.log(result.output);
        console.log(result.code);
}, function(err){
        console.log('Got Error');
        console.error(err);
})
```

This is equivalent to running the following command on a windows commandline instance:
`c:\cygwin64\bin\bash.exe -c "/usr/bin/ansible cisco -m ping"`

The path to ansible must be explicit in the `bash -c` call.
