### PR TITLE
Execute AdHoc or Playbook command with a vault password file

### DIFF
--- a/lib/ansible.js
+++ b/lib/ansible.js
@@ -103,6 +103,11 @@ AbstractAnsibleCommand.prototype.asSudo = function() {
   return this;
 };
 
+AbstractAnsibleCommand.prototype.vaultPasswordFile = function(vaultPasswordFile) {
+  this.config.vaultPasswordFile = vaultPasswordFile;
+  return this;
+};
+
 AbstractAnsibleCommand.prototype.addParam = function(commandParams, param, flag) {
   if (this.config[param]) {
     return this.addParamValue(commandParams, this.config[param], flag)
@@ -143,6 +148,7 @@ AbstractAnsibleCommand.prototype.commonCompileParams = function(commandParams) {
   commandParams = this.addParam(commandParams, "limit", "l");
   commandParams = this.addParam(commandParams, "su", "U");
   commandParams = this.addPathParam(commandParams, "privateKey", "-private-key");
+  commandParams = this.addParam(commandParams, "vaultPasswordFile", "-vault-password-file");
   commandParams = this.addVerbose(commandParams);
   commandParams = this.addSudo(commandParams);
 

--- a/test/adhoc.spec.js
+++ b/test/adhoc.spec.js
@@ -157,6 +157,17 @@ describe('AdHoc command', function() {
     })
   })
 
+  describe('with vault password file', function() {
+
+    it('should contain vault password file in execution', function(done) {
+      var command = new AdHoc().module('shell').hosts('local').args("echo 'hello'").vaultPasswordFile("/vault.txt");
+      expect(command.exec()).to.be.fulfilled.then(function() {
+        expect(spawnSpy).to.be.calledWith('ansible', ['local', '-m', 'shell', '-a', 'echo \'hello\'', '--vault-password-file', '/vault.txt']);
+        done();
+      }).done();
+    })
+  })
+
   after(function() {
     process.spawn = oldSpawn;
     spawnSpy.restore();

--- a/test/playbook.spec.js
+++ b/test/playbook.spec.js
@@ -164,6 +164,18 @@ describe('Playbook command', function () {
 
   })
 
+  describe('with vault password file', function() {
+
+    it('should execute the playbook with specified vault password file', function (done) {
+      var command = new Playbook().playbook('test').vaultPasswordFile("/vault.txt");
+      expect(command.exec()).to.be.fulfilled.then(function () {
+        expect(spawnSpy).to.be.calledWith('ansible-playbook' ,['test.yml', '--vault-password-file', '/vault.txt']);
+        done();
+      }).done();
+    })
+
+  })
+
   describe('with working directory', function () {
 
     var path = require('path');


### PR DESCRIPTION
This commit allows a developer to specify the --vault-password-file argument.
