### PR TITLE
Added error handling for spawning process

### DIFF
--- a/lib/ansible.js
+++ b/lib/ansible.js
@@ -12,6 +12,8 @@ var AbstractAnsibleCommand = function() {
 
 inherits(AbstractAnsibleCommand, EventEmitter);
 
+console.log('test');
+
 AbstractAnsibleCommand.prototype.exec = function(options) {
   // Validate execution configuration
   var errors = this.validate();
@@ -49,11 +51,15 @@ AbstractAnsibleCommand.prototype.exec = function(options) {
     self.emit('stderr', data);
   });
 
+  child.on('error', function(e) {
+	deferred.reject(new Error(output, e));
+  });
+  
   child.on('close', function(code) {
     self.emit('close', code);
     deferred.resolve({code: code, output: output});
   });
-
+  
   child.on('exit', function(code) {
     if (code !== 0) {
       deferred.reject(new Error(output, code));

--- a/lib/ansible.js
+++ b/lib/ansible.js
@@ -12,8 +12,6 @@ var AbstractAnsibleCommand = function() {
 
 inherits(AbstractAnsibleCommand, EventEmitter);
 
-console.log('test');
-
 AbstractAnsibleCommand.prototype.exec = function(options) {
   // Validate execution configuration
   var errors = this.validate();
@@ -52,7 +50,7 @@ AbstractAnsibleCommand.prototype.exec = function(options) {
   });
 
   child.on('error', function(e) {
-	deferred.reject(new Error(output, e));
+	deferred.reject(e);
   });
   
   child.on('close', function(code) {


### PR DESCRIPTION
Currently when you get an error while spawning process it's crashing the app.
This is happening because of the Promise wrapping, there's listeners to few events, but not to "error"