### PR TITLE
Allow custom env variables to be passed to commands

### DIFF
--- a/lib/ansible.js
+++ b/lib/ansible.js
@@ -36,6 +36,11 @@ AbstractAnsibleCommand.prototype.exec = function(options) {
   processOptions.env = process.env;
   _.extend( processOptions.env, { PYTHONUNBUFFERED: unbuffered } );
 
+  // Include user specified environmental variables
+  if (options.env) {
+    _.extend(processOptions.env, options.env);
+  }
+
   var output = '';
   var child = exec.spawn(this.commandName(), this.compileParams(), processOptions);
 

--- a/test/playbook.spec.js
+++ b/test/playbook.spec.js
@@ -207,6 +207,24 @@ describe('Playbook command', function () {
 
   })
 
+  describe('with env variables', function () {
+
+    it('include the variables', function (done) {
+      var command = new Playbook().playbook('test');
+      var promise = command.exec({
+        env: {
+          TEST_ENV: 'true'
+        }
+      });
+
+      expect(promise).to.be.fulfilled.then(function () {
+        expect(spawnSpy).to.be.calledWith('ansible-playbook', ['test.yml']);
+        expect(spawnSpy.getCall(0).args[2]).to.have.deep.property( "env.TEST_ENV", "true" );
+        done();
+      }).done();
+    })
+  })
+
   describe('with --ask-pass flag', function() {
 
     it('should execute the playbook with --ask-pass flag', function (done) {


### PR DESCRIPTION
Pretty simple, allow injection of env variables in to the spawn command for ansible. 