### PR TITLE
Support specifying multiple inventories

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -96,6 +96,8 @@ command.forks(4)
 command.user('root')
 //  -i /etc/ansible/hosts
 command.inventory('/etc/ansible/hosts')
+//  -i /etc/ansible/hosts1 -i /etc/ansible/hosts2
+command.inventory(['/etc/ansible/hosts1', '/etc/ansible/hosts2'])
 //  -U root
 command.su('root');
 //  --private-key filename

--- a/lib/ansible.js
+++ b/lib/ansible.js
@@ -105,7 +105,14 @@ AbstractAnsibleCommand.prototype.asSudo = function() {
 
 AbstractAnsibleCommand.prototype.addParam = function(commandParams, param, flag) {
   if (this.config[param]) {
-    return this.addParamValue(commandParams, this.config[param], flag)
+      var config = this.config[param];
+      if (Array.isArray(config)) {
+        config.forEach((config_item) => {
+            commandParams = this.addParamValue(commandParams, config_item, flag);
+        })
+      } else {
+        commandParams = this.addParamValue(commandParams, config, flag);
+      }
   }
   return commandParams;
 };

--- a/package.json
+++ b/package.json
@@ -31,5 +31,6 @@
     "mock-spawn": "^0.2.6",
     "q": "~1.0.0",
     "underscore": "~1.5.2"
-  }
+  },
+  "files": ["lib"]
 }

--- a/test/adhoc.spec.js
+++ b/test/adhoc.spec.js
@@ -134,6 +134,17 @@ describe('AdHoc command', function() {
     })
   })
 
+  describe('with two inventories', function() {
+
+    it('should contain two inventory flags in execution', function(done) {
+      var command = new AdHoc().module('shell').hosts('local').args("echo 'hello'").inventory(["/etc/my/hosts", "/etc/my/hosts2"]);
+      expect(command.exec()).to.be.fulfilled.then(function() {
+        expect(spawnSpy).to.be.calledWith('ansible', ['local', '-m', 'shell', '-a', 'echo \'hello\'', '-i', '/etc/my/hosts', '-i', '/etc/my/hosts2']);
+        done();
+      }).done();
+    })
+  })
+
   describe('with inventory subset', function() {
 
     it('should execute the playbook with specified inventory subset limit', function (done) {


### PR DESCRIPTION
Sometimes I need to specify multiple inventories, e.g. `ansible-playbook -i inventory/common -i inventory/web playbooks/foo.yml`. Added support for that. 