### PR TITLE
feat(adHoc/become): add become support

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -193,7 +193,10 @@ command.exec();</pre></div>
         
           <div class='highlight'><pre>command.asSudo();</pre></div>
         
-      
+        <p> --become</p>
+
+        
+        <div class='highlight'><pre>command.asBecome();</pre></div>
         
         <p> -k</p>
 
@@ -206,8 +209,6 @@ command.exec();</pre></div>
 
         
           <div class='highlight'><pre>command.askSudoPass();</pre></div>
-        
-      
         
         <p>verbose level: accepts any level supported by the CLI</p>
 

--- a/lib/ansible.js
+++ b/lib/ansible.js
@@ -103,6 +103,11 @@ AbstractAnsibleCommand.prototype.asSudo = function() {
   return this;
 };
 
+AbstractAnsibleCommand.prototype.asBecome = function() {
+  this.config.become = true;
+  return this;
+};
+
 AbstractAnsibleCommand.prototype.addParam = function(commandParams, param, flag) {
   if (this.config[param]) {
     return this.addParamValue(commandParams, this.config[param], flag)
@@ -136,6 +141,13 @@ AbstractAnsibleCommand.prototype.addSudo = function(commandParams) {
   return commandParams;
 };
 
+AbstractAnsibleCommand.prototype.addBecome = function(commandParams) {
+  if (this.config.become) {
+    commandParams = commandParams.concat('--become');
+  }
+  return commandParams;
+};
+
 AbstractAnsibleCommand.prototype.commonCompileParams = function(commandParams) {
   commandParams = this.addParam(commandParams, "forks", "f");
   commandParams = this.addParam(commandParams, "user", "u");
@@ -145,6 +157,7 @@ AbstractAnsibleCommand.prototype.commonCompileParams = function(commandParams) {
   commandParams = this.addPathParam(commandParams, "privateKey", "-private-key");
   commandParams = this.addVerbose(commandParams);
   commandParams = this.addSudo(commandParams);
+  commandParams = this.addBecome(commandParams);
 
   return commandParams;
 };

--- a/test/adhoc.spec.js
+++ b/test/adhoc.spec.js
@@ -112,6 +112,17 @@ describe('AdHoc command', function() {
     })
   })
 
+  describe('as become', function() {
+
+    it('should contain sudo user flag in execution', function(done) {
+      var command = new AdHoc().module('shell').hosts('local').args("echo 'hello'").asBecome();
+      expect(command.exec()).to.be.fulfilled.then(function() {
+        expect(spawnSpy).to.be.calledWith('ansible', ['local', '-m', 'shell', '-a', 'echo \'hello\'', '--become']);
+        done();
+      }).done();
+    })
+  })
+
   describe('with sudo user specified', function() {
 
     it('should contain sudo user flag in execution', function(done) {


### PR DESCRIPTION
Add `--become` support to AdHoc command. 

```command.asBecome();```

**outputs**

```
ansible local -m shell -a "echo 'hello'" --become
```